### PR TITLE
Exclude vendor/** from .rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - 'db/migrate/*.rb'  # Never correct these auto-generated files
     - 'db/schema.rb'     # Never correct these auto-generated files
     - 'vendor/**'        # Never correct someone else's files
+    - 'vendor/**/*'      # Never correct someone else's files
 
 Metrics/BlockLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 ---
 AllCops:
   Exclude:
-    - 'bin/*'         # Never correct these auto-generated files
+    - 'bin/*'            # Never correct these auto-generated files
     - 'db/migrate/*.rb'  # Never correct these auto-generated files
     - 'db/schema.rb'     # Never correct these auto-generated files
-    - 'vendor/*'         # Never correct someone else's files
+    - 'vendor/**'        # Never correct someone else's files
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
Part of upgrading rubocop was removing my old todo files and just... using a nearly-default rubocop config like I advocate doing.

I forgot that Travis CI has a whole `vendor` directory for all of my included gems.

Travis CI is failing right now because of a rubocop violation in the gem `httparty`.