### PR TITLE
Update the CI badge to TravisCI.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ it is licensed under the [GPLv3][].
 [GPLv3]: http://www.gnu.org/copyleft/gpl.html
 
 
-[![Build Status](https://travis-ci.org/michaelabon/bucket.svg?branch=master)](https://travis-ci.org/michaelabon/bucket)
+[![Build Status](https://travis-ci.com/michaelabon/bucket.svg?branch=master)](https://travis-ci.com/michaelabon/bucket)
 
 
 # Using Bucket


### PR DESCRIPTION
The integration between GitHub and TravisCI seems broken when I'm using travis-ci.org. By migrating to the travis-ci.com domain, I hope to have GitHub know that I'm running checks again.