### PR TITLE
fix: fix travis build for ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+dist: focal
 before_install:
   -
     gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: focal
 before_install:
   -
     gem install bundler
+  -
+    sudo /etc/init.d/postgresql start
 before_script:
   -
     psql -c 'create database travis_ci_test;' -U postgres


### PR DESCRIPTION
# Problem

rvm is not working with travis-ci at the moment

# Solution

This is a temporary fix until https://github.com/rvm/rvm/issues/5133 is addressed.