### PR TITLE
Move dependabot updates from Monday morning to Tuesday afternoon

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "15:10"
+      timezone: "America/Winnipeg"
     allow:
       -
         "dependency-type": "all"


### PR DESCRIPTION
Not a great way to start the week, to have all my repositories email me.